### PR TITLE
Add issue templates and other repo items

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: Bug Report
+description: File a defect related to this project
+title: '[BUG]'
+labels:
+- bug
+body:
+- type: input
+  attributes:
+    label: Version
+    description: Version of the extension in which you encountered or noticed this issue
+    placeholder: 'for eg: v.0.0.1'
+  validations:
+      required: true
+- type: dropdown
+  attributes:
+    label: Category
+    multiple: true
+    description: This bug is affects
+    options:
+      - Performance
+      - Functionality
+      - Comprehensibility (Documentation)
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Issue Description
+    description: What happened?
+    placeholder: Tell us what happened, if you have any steps to reproduce the behavior it would be great! You can also attach extension logs if required.( https://stackoverflow.com/a/54381900 ). 
+  validations:
+      required: true
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: What was supposed to happen?
+    placeholder: Tell us what was supposed to happen (optional)
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/A-0-5/gostmortem-table?tab=coc-ov-file#readme)
+    options:
+      - label: I agree to follow this project's Code of Conduct
+        required: true

--- a/.github/ISSUE_TEMPLATE/enhancement_request.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.yml
@@ -1,0 +1,20 @@
+name: Enhancements
+description: Request feature enhancements
+title: '[ENHANCEMENT]'
+labels:
+- enhancement
+body:
+- type: textarea
+  attributes:
+    label: Enhancement Idea
+    description: What would you like to improve about this component?
+    placeholder: Tell us more about what you'd like to improve (and how you'd like to see it done if you have any ideas/suggestions)
+  validations:
+      required: true
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/A-0-5/gostmortem-table?tab=coc-ov-file#readme)
+    options:
+      - label: I agree to follow this project's Code of Conduct
+        required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,20 @@
+name: New Feature Request
+description: Request for a new feature to be added as part of this project
+title: '[FEATURE] '
+labels:
+- feature
+body:
+- type: textarea
+  attributes:
+    label: Feature Description
+    description: What new feature would you like to see implemented?
+    placeholder: Tell us more about your awesome feature/idea you'd like to see as a part of this project
+  validations:
+      required: true
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/A-0-5/gostmortem-table?tab=coc-ov-file#readme)
+    options:
+      - label: I agree to follow this project's Code of Conduct
+        required: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 build/
 out/
+.DS_Store

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing Guide
+
+All contributions to this repository shall be subject to the following guidelines
+
+  - Please try to keep your contributions linked to an issue. You can create a new issue if required or work on an existing issue.
+  - Please add as much context as possible in the issue like the expected outcome for the issue to be closed in case of feature requests and enhancements.
+  - Please add as much context for bugs.
+  - Upon completing the changes please raise a pull request from your fork to the source. Try to follow the 7 rules for a commit message which are
+    1. Limit the subject line to 50 characters.
+    2. Capitalize only the first letter in the subject line.
+    3. Don't put a period at the end of the subject line.
+    4. Put a blank line between the subject line and the body.
+    5. Wrap the body at 72 characters.
+    6. Use the imperative mood.
+    7. Describe what was done and why, but not how.
+  - Be sure to reference the issue at the end of the commit message using `closes` keyword. Eg: `closes #<issue_number>`
+  - Optionally you may choose to justify the commit message body as well.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ The parser component [gostackparser.go](src/gostackparser.ts) is based on  [gost
 
 
 Any feedback is welcome.
+
+> PS: I'm new to typescript and frontend development in general. I've built this extension using my limited knowledge of html, css and ts that I was able to learn in a week. Please do not hesitate to point out any issues in terms of code quality as it also helps me learn.


### PR DESCRIPTION
This commit adds issue templates to streamline  issue  reporting.   This
commit also adds a contributing guide and code of conduct for the  repo.

closes #3